### PR TITLE
OperationResult updated. Stack trace logging here.

### DIFF
--- a/src/web-fls-quiz/Interfaces/IOperationResult.cs
+++ b/src/web-fls-quiz/Interfaces/IOperationResult.cs
@@ -1,5 +1,5 @@
 namespace WebFlsQuiz.Interfaces
 {
-    public interface IOperationResult<T> { }
+    public interface IOperationResult<out T> { }
     public interface IOperationResult { }
 }

--- a/src/web-fls-quiz/Models/OperationResult.cs
+++ b/src/web-fls-quiz/Models/OperationResult.cs
@@ -94,7 +94,7 @@ namespace WebFlsQuiz.Models
             switch (source)
             {
                 case OperationResult.FailureResult<T> failure:
-                    logger.LogCritical(failure.Exception.Message);
+                    logger.LogCritical($"Error message: {failure.Exception.Message}, Stack trace: {failure.Exception.StackTrace}");
                     return source;
                 default: return source;
             }
@@ -104,7 +104,7 @@ namespace WebFlsQuiz.Models
             switch (source)
             {
                 case OperationResult.FailureResult failure:
-                    logger.LogCritical(failure.Exception.Message);
+                    logger.LogCritical($"Error message: {failure.Exception.Message}, Stack trace: {failure.Exception.StackTrace}");
                     return source;
                 default: return source;
             }


### PR DESCRIPTION
#66
`T` is now covariant in `IOperationResult<T>`. The error logging contains a stack trace.